### PR TITLE
Add support for ZOBEX DD-FDC disks (8", DSDD/SSDD, CP/M 2.2)

### DIFF
--- a/diskdefs.cfg
+++ b/diskdefs.cfg
@@ -113,3 +113,29 @@ disk maganavox.videowriter
         bps = 256
     end
 end
+
+# ZOBEX DD-FDC DSDD
+disk zobex-dsdd
+    cyls = 77
+    heads = 2
+    tracks * ibm.mfm
+        secs = 16
+        bps = 512
+        rpm = 360
+        interleave = 3
+        id = 0
+    end
+end
+
+# ZOBEX DD-FDC SSDD
+disk zobex-ssdd
+    cyls = 77
+    heads = 1
+    tracks * ibm.mfm
+        secs = 16
+        bps = 512
+        rpm = 360
+        interleave = 3
+        id = 0
+    end
+end

--- a/gw-cpm.zobex-dsdd
+++ b/gw-cpm.zobex-dsdd
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Format: 		CP/M 2.2 for ZOBEX DD-FDC controller, DSDD media
+# gw diskdef: 		zobex-dsdd
+# External tools:	cpmtools (https://github.com/lipro-cpm4l/cpmtools)
+
+# Get project name
+name="$1"
+
+# Include parent script
+if [[ -f "./gw-raw" ]]
+then
+	parent="./gw-raw"
+else
+	parent="$(which gw-raw)"
+fi
+source "$parent" "$name" "source"
+
+# Output file names
+img="$name.img"
+
+
+# Overloaded function from gw-raw
+function decode # 1-Nothing
+{
+	echo "Decoding Zobex DSDD CP/M disk"
+	gw convert --diskdefs $diskdefs --format zobex-dsdd "$raw" "$img"  2>&1 | tee -a $log_decode
+}
+
+
+# Overloaded function from gw-raw
+# Need custom cpmtools disk diskdef
+# # ZOBEX DD-FDC controller, DSDD media
+# # per CP/M V2.2 CBIOS for ZOBEX DD-FDC controller (30-Sep-81)
+# diskdef zobex-dsdd
+#   seclen 512
+#   tracks 154
+#   sectrk 16
+#   maxdir 256
+#   blocksize 4096
+#   skew 0
+#   boottrk 2
+#   os 2.2
+# end
+
+function extract # 1-Nothing
+{
+	echo "Extract files from [$img] here as a verification step"
+	#file "$img"  2>&1 | tee -a $log_extract
+
+	format="zobex-dsdd"
+	dest="$name-files"
+
+	# System dir creation
+	mkdir -p "$dest"
+
+	# Get files in copy
+	cpmls -f $format "$img" 2>&1 | tee -a $log_extract
+	cpmfiles=( $(cpmls -f $format "$img") )
+	if [[ "$(cpmls -f $format "$img" 2>&1 | grep "/")" != "" ]]
+	then
+		echo "CP/M files with '/' detected, replacing with '_'" 2>&1 | tee -a $log_extract
+	fi
+
+	# Extract each file from image
+	for line in "${cpmfiles[@]}"
+	do
+	    if [[ "$line" == "0:" ]]
+	    then
+		continue
+	    fi
+	    echo "Extracting: [$line]"
+	    cpmcp -f $format "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
+
+	done
+}
+
+
+# Create dir based on name and rip within it
+mkdir -p "$name"
+cd "$name"
+rip A "h=0-1:c=0-76"
+cd ..

--- a/gw-cpm.zobex-ssdd
+++ b/gw-cpm.zobex-ssdd
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Format: 		CP/M 2.2 for ZOBEX DD-FDC controller, SSDD media
+# gw diskdef: 		zobex-ssdd
+# External tools:	cpmtools (https://github.com/lipro-cpm4l/cpmtools)
+
+# Get project name
+name="$1"
+
+# Include parent script
+if [[ -f "./gw-raw" ]]
+then
+	parent="./gw-raw"
+else
+	parent="$(which gw-raw)"
+fi
+source "$parent" "$name" "source"
+
+# Output file names
+img="$name.img"
+
+
+# Overloaded function from gw-raw
+function decode # 1-Nothing
+{
+	echo "Decoding Zobex SSDD CP/M disk"
+	gw convert --diskdefs $diskdefs --format zobex-ssdd "$raw" "$img"  2>&1 | tee -a $log_decode
+}
+
+
+# Overloaded function from gw-raw
+# Need custom cpmtools disk diskdef
+# # ZOBEX DD-FDC controller, SSDD media
+# # per CP/M V2.2 CBIOS for ZOBEX DD-FDC controller (30-Sep-81)
+# diskdef zobex-ssdd
+#   seclen 512
+#   tracks 77
+#   sectrk 16
+#   maxdir 128
+#   blocksize 2048
+#   skew 0
+#   boottrk 1
+#   os 2.2
+# end
+
+function extract # 1-Nothing
+{
+	echo "Extract files from [$img] here as a verification step"
+	#file "$img"  2>&1 | tee -a $log_extract
+
+	format="zobex-ssdd"
+	dest="$name-files"
+
+	# System dir creation
+	mkdir -p "$dest"
+
+	# Get files in copy
+	cpmls -f $format "$img" 2>&1 | tee -a $log_extract
+	cpmfiles=( $(cpmls -f $format "$img") )
+	if [[ "$(cpmls -f $format "$img" 2>&1 | grep "/")" != "" ]]
+	then
+		echo "CP/M files with '/' detected, replacing with '_'" 2>&1 | tee -a $log_extract
+	fi
+
+	# Extract each file from image
+	for line in "${cpmfiles[@]}"
+	do
+	    if [[ "$line" == "0:" ]]
+	    then
+		continue
+	    fi
+	    echo "Extracting: [$line]"
+	    cpmcp -f $format "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
+
+	done
+}
+
+
+# Create dir based on name and rip within it
+mkdir -p "$name"
+cd "$name"
+rip A "h=0:c=0-76"
+cd ..


### PR DESCRIPTION
This work was based on the flux images shared by Snekers over on the Discord, which contained CP/M 2.2 and a fair chunk of documentation and source code relating to ZOBEX DD-FDC disk controller.  The Greaseweazle diskdef was straightforward enough to derive from the flux images (16 512-byte sectors per track, zero-indexed, 77 tracks), and then the `cpmtools` diskdef was derived from the CP/M BIOS source code found in the initial recovery.

I've tested the `gw-cpm.zobex-dsdd` script against the four images that have been shared so far and it works as expected (all three disks have at least one damaged section but everything that can be decoded and extracted looks correct).  The `gw-cpm.zobex-ssdd` script is as-yet untested, but I've included it in case Snekers stumbles across any single-sided disks in the collection they're archiving.