### PR TITLE
Embed custom CP/M diskdefs in scripts, where appropriate

### DIFF
--- a/extract-cpm-diskdef
+++ b/extract-cpm-diskdef
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -ue	# report unset variables and unexpected error exit states
+
+# does the user need help?  if so, display blurb and go no further
+case "${1:---help}"
+in
+	--help | -h )
+		echo "Usage: $0 filename..."
+		echo ""
+		echo "Extracts custom cpmtools diskdefs from these scripts, in a format suitable"
+		echo "for including in /usr/local/share/diskdefs, and prints them to stdout."
+		echo ""
+		exit
+		;;
+esac
+
+# we need to run the supplied filenames through our pipeline individually
+for filename in "$@"
+do
+	# this ed command breaks down as follows:
+	#    g                  apply command globally - suppresses errors if no matches
+	#    /^cpm_diskdef=/    find first line starting 'cpm_diskdef='
+	#    ;?^$?              find first empty line before the one we just found
+	#    +1                 ... and then select the line after it
+	#    ;/^end/            ... and now select the next line starting 'end'
+	#    p                  finally, print the block between the last two selections
+	#
+	# we then pipe the selected block of text through sed to trim off the variable bits
+	# which should leave us with the diskdef block we want!
+
+	echo 'g/^cpm_diskdef=/;?^$?+1;/^end/p' |
+		ed -s - "$filename" |
+		sed -e 's/^cpm_diskdef="//' -e 's/^end"/end\n/' -e 's/^# #/#/'
+done

--- a/gw-cpm.86
+++ b/gw-cpm.86
@@ -30,34 +30,35 @@ function decode # 1-Nothing
 
 # Overloaded function from gw-rawo
 # Need custom cpmtools disk diskdef
-# # CompuPro CPM/86?
-# diskdef comp86
-#   seclen 1024
-#   tracks 70
-#   sectrk 8
-#   blocksize 1024
-#   maxdir 64
-#   skew 3
-#   offset 11520
-#   boottrk 0
-#   os 2.2
-# end
+
+# CompuPro CPM/86?
+cpm_diskdef="diskdef comp86
+  seclen 1024
+  tracks 70
+  sectrk 8
+  blocksize 1024
+  maxdir 64
+  skew 3
+  offset 11520
+  boottrk 0
+  os 2.2
+end"
 
 function extract # 1-Nothing
 {
 	echo "Extract files from [$img] here as a verification step"
 	#file "$img"  2>&1 | tee -a $log_extract
 
-	format="comp86"
+	format="$cpm_diskdef"
 	dest="$name-files"
 
 	# System dir creation
 	mkdir -p "$dest"
 
 	# Get files in copy
-	cpmls -f $format "$img" 2>&1 | tee -a $log_extract
-	cpmfiles=( $(cpmls -f $format "$img") )
-	if [[ "$(cpmls -f $format "$img" 2>&1 | grep "/")" != "" ]]
+	cpmls -f "$format" "$img" 2>&1 | tee -a $log_extract
+	cpmfiles=( $(cpmls -f "$format" "$img") )
+	if [[ "$(cpmls -f "$format" "$img" 2>&1 | grep "/")" != "" ]]
 	then
 		echo "CP/M files with '/' detected, replacing with '_'" 2>&1 | tee -a $log_extract
 	fi
@@ -70,7 +71,7 @@ function extract # 1-Nothing
 		continue
 	    fi
 	    echo "Extracting: [$line]"
-	    cpmcp -f $format "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
+	    cpmcp -f "$format" "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
 
 	done
 }

--- a/gw-cpm.86ds
+++ b/gw-cpm.86ds
@@ -30,18 +30,19 @@ function decode # 1-Nothing
 
 # Overloaded function from gw-rawo
 # Need custom cpmtools disk diskdef
-# # CompuPro CPM/86?
-# diskdef comp86
-#   seclen 1024
-#   tracks 70
-#   sectrk 8
-#   blocksize 1024
-#   maxdir 64
-#   skew 3
-#   offset 11520
-#   boottrk 0
-#   os 2.2
-# end
+
+# CompuPro CPM/86?
+cpm_diskdef="diskdef comp86
+  seclen 1024
+  tracks 70
+  sectrk 8
+  blocksize 1024
+  maxdir 64
+  skew 3
+  offset 11520
+  boottrk 0
+  os 2.2
+end"
 
 function extract # 1-Nothing
 {
@@ -55,9 +56,9 @@ function extract # 1-Nothing
 	mkdir -p "$dest"
 
 	# Get files in copy
-	cpmls -f $format "$img" 2>&1 | tee -a $log_extract
-	cpmfiles=( $(cpmls -f $format "$img") )
-	if [[ "$(cpmls -f $format "$img" 2>&1 | grep "/")" != "" ]]
+	cpmls -f "$format" "$img" 2>&1 | tee -a $log_extract
+	cpmfiles=( $(cpmls -f "$format" "$img") )
+	if [[ "$(cpmls -f "$format" "$img" 2>&1 | grep "/")" != "" ]]
 	then
 		echo "CP/M files with '/' detected, replacing with '_'" 2>&1 | tee -a $log_extract
 	fi
@@ -70,7 +71,7 @@ function extract # 1-Nothing
 		continue
 	    fi
 	    echo "Extracting: [$line]"
-	    cpmcp -f $format "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
+	    cpmcp -f "$format" "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
 
 	done
 }

--- a/gw-cpm.zobex-dsdd
+++ b/gw-cpm.zobex-dsdd
@@ -30,34 +30,35 @@ function decode # 1-Nothing
 
 # Overloaded function from gw-raw
 # Need custom cpmtools disk diskdef
-# # ZOBEX DD-FDC controller, DSDD media
-# # per CP/M V2.2 CBIOS for ZOBEX DD-FDC controller (30-Sep-81)
-# diskdef zobex-dsdd
-#   seclen 512
-#   tracks 154
-#   sectrk 16
-#   maxdir 256
-#   blocksize 4096
-#   skew 0
-#   boottrk 2
-#   os 2.2
-# end
+
+# ZOBEX DD-FDC controller, DSDD media
+# per CP/M V2.2 CBIOS for ZOBEX DD-FDC controller (30-Sep-81)
+cpm_diskdef="diskdef zobex-dsdd
+   seclen 512
+   tracks 154
+   sectrk 16
+   maxdir 256
+   blocksize 4096
+   skew 0
+   boottrk 2
+   os 2.2
+end"
 
 function extract # 1-Nothing
 {
 	echo "Extract files from [$img] here as a verification step"
 	#file "$img"  2>&1 | tee -a $log_extract
 
-	format="zobex-dsdd"
+	format="$cpm_diskdef"
 	dest="$name-files"
 
 	# System dir creation
 	mkdir -p "$dest"
 
 	# Get files in copy
-	cpmls -f $format "$img" 2>&1 | tee -a $log_extract
-	cpmfiles=( $(cpmls -f $format "$img") )
-	if [[ "$(cpmls -f $format "$img" 2>&1 | grep "/")" != "" ]]
+	cpmls -f "$format" "$img" 2>&1 | tee -a $log_extract
+	cpmfiles=( $(cpmls -f "$format" "$img") )
+	if [[ "$(cpmls -f "$format" "$img" 2>&1 | grep "/")" != "" ]]
 	then
 		echo "CP/M files with '/' detected, replacing with '_'" 2>&1 | tee -a $log_extract
 	fi
@@ -70,7 +71,7 @@ function extract # 1-Nothing
 		continue
 	    fi
 	    echo "Extracting: [$line]"
-	    cpmcp -f $format "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
+	    cpmcp -f "$format" "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
 
 	done
 }

--- a/gw-cpm.zobex-ssdd
+++ b/gw-cpm.zobex-ssdd
@@ -30,34 +30,35 @@ function decode # 1-Nothing
 
 # Overloaded function from gw-raw
 # Need custom cpmtools disk diskdef
-# # ZOBEX DD-FDC controller, SSDD media
-# # per CP/M V2.2 CBIOS for ZOBEX DD-FDC controller (30-Sep-81)
-# diskdef zobex-ssdd
-#   seclen 512
-#   tracks 77
-#   sectrk 16
-#   maxdir 128
-#   blocksize 2048
-#   skew 0
-#   boottrk 1
-#   os 2.2
-# end
+
+# ZOBEX DD-FDC controller, SSDD media
+# per CP/M V2.2 CBIOS for ZOBEX DD-FDC controller (30-Sep-81)
+cpm_diskdef="diskdef zobex-ssdd
+  seclen 512
+  tracks 77
+  sectrk 16
+  maxdir 128
+  blocksize 2048
+  skew 0
+  boottrk 1
+  os 2.2
+end"
 
 function extract # 1-Nothing
 {
 	echo "Extract files from [$img] here as a verification step"
 	#file "$img"  2>&1 | tee -a $log_extract
 
-	format="zobex-ssdd"
+	format="$cpm_diskdef"
 	dest="$name-files"
 
 	# System dir creation
 	mkdir -p "$dest"
 
 	# Get files in copy
-	cpmls -f $format "$img" 2>&1 | tee -a $log_extract
-	cpmfiles=( $(cpmls -f $format "$img") )
-	if [[ "$(cpmls -f $format "$img" 2>&1 | grep "/")" != "" ]]
+	cpmls -f "$format" "$img" 2>&1 | tee -a $log_extract
+	cpmfiles=( $(cpmls -f "$format" "$img") )
+	if [[ "$(cpmls -f "$format" "$img" 2>&1 | grep "/")" != "" ]]
 	then
 		echo "CP/M files with '/' detected, replacing with '_'" 2>&1 | tee -a $log_extract
 	fi
@@ -70,7 +71,7 @@ function extract # 1-Nothing
 		continue
 	    fi
 	    echo "Extracting: [$line]"
-	    cpmcp -f $format "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
+	    cpmcp -f "$format" "$img" "0:$line" "$dest/$(echo "$line" | sed 's|/|_|')"
 
 	done
 }

--- a/gw-jonos.35
+++ b/gw-jonos.35
@@ -30,32 +30,33 @@ function decode # 1-Nothing
 
 # Overloaded function from gw-raw
 # Extracting requires the following custom diskdef for cpmtools in: /etc/cpmtools/diskdefs
-#
-# # Jonos Courier/Escort C2100
-# diskdef jonos35
-#    seclen 512
-#    tracks 70
-#    sectrk 9
-#    blocksize 2048
-#    maxdir 64
-#    skew 0
-#    boottrk 2
-#    os 3
-# end
+
+# Jonos Courier/Escort C2100
+cpm_diskdef="diskdef jonos35
+   seclen 512
+   tracks 70
+   sectrk 9
+   blocksize 2048
+   maxdir 64
+   skew 0
+   boottrk 2
+   os 3
+end"
+
 function extract
 {
 	echo "Extract files from [$img] here as a verification step"
 	#file "$img"  2>&1 | tee -a $log_extract
 
-	format="jonos35"
+	format="$cpm_diskdef"
 	dest="$name-files"
 
 	# System dir creation
 	mkdir -p "$dest"
 
 	# Get files in copy
-	cpmls -f $format "$img" 2>&1 | tee -a $log_extract
-	cpmfiles=( $(cpmls -f $format "$img") )
+	cpmls -f "$format" "$img" 2>&1 | tee -a $log_extract
+	cpmfiles=( $(cpmls -f "$format" "$img") )
 
 	# Extract each file from image
 	for line in "${cpmfiles[@]}"
@@ -65,7 +66,7 @@ function extract
 		continue
 	    fi
 	    echo "Extracting: [$line]"
-	    cpmcp -f $format "$img" "0:$line" "$dest/$line"
+	    cpmcp -f "$format" "$img" "0:$line" "$dest/$line"
 
 	done
 


### PR DESCRIPTION
As discussed in issue #5 the other evening - `cpmtools` allows us to pass our custom diskdefs directly, instead of requiring the user to update their `diskdefs` file.  (Turns out this file lives in a different place on Debian-derived distros than I thought from my local installation, which added further confusion when trying to help something through using the scripts on Discord yesterday!)

For each script with a custom diskdef I've moved it into a `cpm_diskdef` variable, changed the `extract` routine to use that variable instead of a diskdef name, and wrapped the `$format` expansions throughout the routine with double quotes so that they cope properly with the spaces in the definitions.

I've also made the formatting of the comment lines before the diskdefs consistent by ensuring there's a blank line before the comment describing the system.  This allows the diskdef blocks to be pulled out and reformatted such that they can be pasted directly into the `diskdefs` file if needed - the `extract-cpm-diskdef` script included does exactly that.